### PR TITLE
Split task submission and tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,18 @@ INFO - TASK_FINISHED: "eremetic-task.232e3359-dead-babe-beef-9872ed82ba90", stat
 ```python
 (u'eremetic-task.232e3359-dead-babe-beef-9872ed82ba90', u'TASK_FINISHED')
 ```
+
+### Separate submission and task tracking
+If you wish to persist the id of the task before blocking your app to wait for it to finish,
+you can separately submit the task:
+
+```python
+task_id = request.submit('http://eremetic-url')
+```
+
+Now you can start tracking the existing task with:
+```python
+request.track('http://eremetic-url', task_id)
+```
+Using this method you can connect to a running task to wait for it to finish
+or to fetch its result if the task has completed.


### PR DESCRIPTION
This PR:
* Adds `submit` and `track` methods which are just parts of existing `to` method
* Changes logging level of the messages in the loop to `DEBUG` to reduce logs clutter

- [x] Production code
- [ ] Testing code
- [x] Documentation

## Description
Split into `submit` and `track` allows to give access to the Eremetic task id to the user. E.g. to persist it or to track the state of the task from somewhere else in the system. `track` allows tracking already existing tasks.

Code was tested manually by submitting example code from README in the Python REPL.

## Review hints

The reviewer is responsible with checking that the pull request:

- adheres to the contribution guidelines
- is small in size and simple to review
- fulfills the original requirements
- checks correctness with unit and integration tests
- checks edge cases throughout tests
- preserves original design choices (or documents variations)
- contains understandable code and tests
- does not introduce unreasonable systemic complexity
- does not introduce unreasonable algorithmic complexity
- does not introduce hard-coded constants or magic numbers
- includes documentation for developers
- includes documentation for users