### PR TITLE
Cancel tracking and task when too long in TASK_QUEUED

### DIFF
--- a/eremetic_synchronous_client.py
+++ b/eremetic_synchronous_client.py
@@ -129,7 +129,7 @@ class Request:
         :param task_state: Mesos task state
         :return:
         """
-        return task_state in {"TASK_LOST", "TASK_KILLED", "TASK_FAILED"}
+        return task_state in {"TASK_LOST", "TASK_KILLED", "TASK_FAILED", "TASK_TERMINATING"}
 
     @staticmethod
     def terminate_task(url, task_id):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
   name = 'eremetic-synchronous-client',
   py_modules=['eremetic_synchronous_client'],
-  version = '0.28.3',
+  version = '0.28.4',
   description = 'A synchronous client for Eremetic',
   author = 'Stefano Baghino',
   author_email = 'stefano.baghino@teralytics.net',


### PR DESCRIPTION
`queue_max_wait_time` argument for `track` method, which adds a behavior to cancel a task when it stays too long in the state `TASK_QUEUED`.

Further to prevent tasks from being stuck in `TASK_TERMINATING` state, added it to the check of the failed terminal states of the task.

Useful as a workaround for bug: https://github.com/eremetic-framework/eremetic/issues/187
